### PR TITLE
Add missing sources

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,9 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "boost.json",
+    srcs = [
+        "src/src.cpp",
+    ],
     hdrs = glob([
         "include/**/*.hpp",
         "include/**/*.ipp",


### PR DESCRIPTION
Without this, linking with the lib gives unresolved symbols.
Could be fixed by including `#include <boost/json/src.hpp>` but that's a separate consuming approach...